### PR TITLE
removed upper case of url :

### DIFF
--- a/operations/src/main/java/com/testingblaze/controller/TestSetupController.java
+++ b/operations/src/main/java/com/testingblaze/controller/TestSetupController.java
@@ -164,7 +164,7 @@ public final class TestSetupController {
      */
     private void runBrowser() {
         device.setupController();
-        device.getDriver().get(EnvironmentFactory.getEnvironmentUrl().toUpperCase());
+        device.getDriver().get(EnvironmentFactory.getEnvironmentUrl());
     }
 
     /**


### PR DESCRIPTION
Reason to update : if the url contains the format such as http://abc.xyz.com/jitu/
and if we upper case it and hit the url then abc.xyz.com remains in small letters and only jitu will be in upper letter