### PR TITLE
Feature mobile emulator run browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,22 @@ docker run --rm -ti --name zalenium -p 4444:4444 \
 Standard Command +<br>
 -Dhub=http:localhost:4444/
 
+#### 7. On Browser in mobile view :
+To run the test cases in chrome browser with mobile view, we can use following command.
+```
+mvn clean verify -Dtags="@yourTagToRun" -DbrowserMode=mobile
+```
+Run test case in custom configuration of a particular mobile emulator in browser
+```
+mvn clean verify -Dtags="@test" -browserMode=mobile -DcustomMobileEmulator=true -Dwidth=300 -Dheight=900
+```
+Run test case in particular emulator's default configuration such as iPad mini and so on.
+```
+mvn clean verify -Dtags="@test" -DbrowserMode=mobile -DdeviceName="iPad Mini"
+```
+There are multiple devices available to load any page in mobile view. You can find it in Developer tool of chrome browser.
+Go to Developer tool -> Select toggle device toolbar(small mobile like icon) -> Under dimentions, you will find different emulators available. 
+
 ####	Other Options: 
 •	Browser Mode: -DbrowserMode=incognito<br>
 •	Switch Environemnts: -Denv=qa <br>

--- a/operations/src/main/java/com/testingblaze/devices/CapabilitiesManager.java
+++ b/operations/src/main/java/com/testingblaze/devices/CapabilitiesManager.java
@@ -25,6 +25,7 @@ import org.openqa.selenium.safari.SafariOptions;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.logging.Level;

--- a/operations/src/main/java/com/testingblaze/devices/CapabilitiesManager.java
+++ b/operations/src/main/java/com/testingblaze/devices/CapabilitiesManager.java
@@ -52,6 +52,20 @@ public class CapabilitiesManager {
             chromeOptions.setCapability(CapabilityType.LOGGING_PREFS, logPrefs);
         }
 
+        if (null != System.getProperty("mobileEmulator") && "true".equalsIgnoreCase(System.getProperty("mobileEmulator"))){
+            Map<String, Object> deviceMetrics = new HashMap<>();
+            Map<String, Object> mobileEmulation = new HashMap<>();
+            if (null != System.getProperty("customMobileEmulator") && "true".equalsIgnoreCase(System.getProperty("customMobileEmulator"))) {
+                deviceMetrics.put("width", System.getProperty("width") == null ? 1078 : Integer.parseInt(System.getProperty("width")));
+                deviceMetrics.put("height", System.getProperty("height") == null ? 924 : Integer.parseInt(System.getProperty("height")));
+                deviceMetrics.put("pixelRatio", System.getProperty("pixelRatio") == null ? 1.0 : System.getProperty("pixelRatio"));
+                mobileEmulation.put("deviceMetrics", deviceMetrics);
+            } else {
+                mobileEmulation.put("deviceName",System.getProperty("deviceName") == null ? "Pixel 5" : System.getProperty("deviceName"));
+            }
+            chromeOptions.setExperimentalOption("mobileEmulation", mobileEmulation);
+        }
+
         chromeOptions.setExperimentalOption("prefs", Map.of(
                 "profile.cookie_controls_mode", 0,
                 "profile.block_third_party_cookies", false,

--- a/operations/src/main/java/com/testingblaze/devices/CapabilitiesManager.java
+++ b/operations/src/main/java/com/testingblaze/devices/CapabilitiesManager.java
@@ -53,7 +53,7 @@ public class CapabilitiesManager {
             chromeOptions.setCapability(CapabilityType.LOGGING_PREFS, logPrefs);
         }
 
-        if (null != System.getProperty("mobileEmulator") && "true".equalsIgnoreCase(System.getProperty("mobileEmulator"))){
+        if (null != System.getProperty("browserMode") && "mobile".equalsIgnoreCase(System.getProperty("browserMode"))){
             Map<String, Object> deviceMetrics = new HashMap<>();
             Map<String, Object> mobileEmulation = new HashMap<>();
             if (null != System.getProperty("customMobileEmulator") && "true".equalsIgnoreCase(System.getProperty("customMobileEmulator"))) {


### PR DESCRIPTION

 Added capability to run the test cases on mobile emulator of browser. This code introduced 2 new system properties
    1. mobileEmulator
    2. customMobileEmulator
    mobileEmulator --> if we set this system property then the test cases will run in mobile emulator of browser. e.g -DcustomMobileEmulator=true
    along with this property, user also needs to set the desired deviceName as system property. e.g -DdeviceName="iPhone 12 Pro"
    Example --> mvn clean verify -Dtags=@test -DmobileEmulator=true -DdeviceName="iPad Mini". This will open chrome browser with given mobile emulator.
    customMobileEmulator -->  Sometime user wants to run the test cases of customize configuration such as width=300 and hight=900.
    So if we want to run the test cases on custom configuration then run following command
    mvn clean verify -Dtags=@test -DmobileEmulator=true -DcustomMobileEmulator=true -Dwidth=300 -Dheight=900